### PR TITLE
Add spinlock C++ implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ OBJS = \
 	proc.o\
 	sleeplock.o\
 	spinlock.o\
+	spinlock_.o\
 	string.o\
 	swtch.o\
 	syscall.o\
@@ -27,7 +28,7 @@ OBJS = \
 	uart.o\
 	vectors.o\
 	vm.o\
-	foo.o\
+
 
 # Cross-compiling (e.g., on Mac OS X)
 # TOOLPREFIX = i386-jos-elf
@@ -79,7 +80,7 @@ LD = $(TOOLPREFIX)ld
 OBJCOPY = $(TOOLPREFIX)objcopy
 OBJDUMP = $(TOOLPREFIX)objdump
 CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -O2 -Wall -MD -ggdb -m32 -fno-omit-frame-pointer
-CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++98
+CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions -std=c++11
 CFLAGS += -Werror=array-bounds=0 -mgeneral-regs-only
 CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 && echo -fno-stack-protector)
 ASFLAGS = -m32 -gdwarf-2 -Wa,-divide

--- a/spinlock.hpp
+++ b/spinlock.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "types.h"
+
+class Spinlock {
+  public:
+    Spinlock(const char *name);
+
+    void acquire();
+    void release();
+    bool holding();
+
+  private:
+    volatile uint locked;
+    const char *name;
+    struct cpu *holder;
+    uint pcs[10];
+
+    void getCallerPcs(void *v, uint pcs[]);
+    void pushcli();
+    void popcli();
+};

--- a/spinlock_.cpp
+++ b/spinlock_.cpp
@@ -1,0 +1,80 @@
+#include "spinlock.hpp"
+
+#include "defs.h"
+#include "memlayout.h"
+#include "mmu.h"
+#include "param.h"
+#include "proc.h"
+#include "types.h"
+#include "x86.h"
+
+inline Spinlock::Spinlock(const char *name)
+    : locked(0), name(name), holder(nullptr) {
+    for (int i = 0; i < 10; ++i)
+        pcs[i] = 0;
+}
+
+inline void Spinlock::acquire() {
+    pushcli();
+    if (holding()) {
+        panic((char *)"Spinlock::acquire: already held");
+    }
+
+    while (__sync_lock_test_and_set(&locked, 1) != 0)
+        ;
+
+    __sync_synchronize();
+
+    holder = mycpu();
+    getCallerPcs((void *)&name, pcs);
+}
+
+inline void Spinlock::release() {
+    if (!holding()) {
+        panic((char *)"Spinlock::release: not held");
+    }
+
+    pcs[0] = 0;
+    holder = nullptr;
+    __sync_synchronize();
+    __asm__ __volatile__("movl $0, %0" : "+m"(locked) :);
+
+    popcli();
+}
+
+inline bool Spinlock::holding() {
+    pushcli();
+    bool r = locked && holder == mycpu();
+    popcli();
+    return r;
+}
+
+inline void Spinlock::getCallerPcs(void *v, uint pcs[]) {
+    uint *ebp = (uint *)v - 2;
+    for (int i = 0; i < 10; ++i) {
+        if (ebp == nullptr || ebp < (uint *)KERNBASE ||
+            ebp == (uint *)0xffffffff)
+            break;
+        pcs[i] = ebp[1];
+        ebp = (uint *)ebp[0];
+    }
+    for (int i = 0; i < 10; ++i)
+        pcs[i] = 0;
+}
+
+inline void Spinlock::pushcli() {
+    int eflags = readeflags();
+    cli();
+    if (mycpu()->ncli == 0)
+        mycpu()->intena = eflags & FL_IF;
+    mycpu()->ncli++;
+}
+
+inline void Spinlock::popcli() {
+    if (readeflags() & FL_IF)
+        panic((char *)"Spinlock::popcli - interruptible");
+    if (--mycpu()->ncli < 0)
+        panic((char *)"Spinlock::popcli");
+    if (mycpu()->ncli == 0 && mycpu()->intena)
+        sti();
+}


### PR DESCRIPTION
Ported ``spinlock.c`` to C++. Keeping ``spinlock.c`` for code that still depends on it